### PR TITLE
fix: fix rust lsp issues and add package for macos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,16 +46,16 @@
     },
     "systems": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "default",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-    systems.url = "github:nix-systems/default-linux";
+    systems.url = "github:nix-systems/default";
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";

--- a/nix/modules/flake/shells.nix
+++ b/nix/modules/flake/shells.nix
@@ -3,13 +3,14 @@
     { pkgs, ... }:
     {
       devShells.default = pkgs.mkShell {
-        buildInputs = [
-          pkgs.alsa-lib.dev
-        ];
+        RUST_SRC_PATH = toString pkgs.rust.packages.stable.rustPlatform.rustLibSrc;
+
+        buildInputs = if pkgs.stdenv.hostPlatform.isLinux then [ pkgs.alsa-lib.dev ] else [ ];
 
         nativeBuildInputs = [
-          pkgs.pkg-config
           pkgs.cargo
+          pkgs.pkg-config
+          pkgs.rustc
         ];
       };
     };

--- a/nix/packages/lrxed/default.nix
+++ b/nix/packages/lrxed/default.nix
@@ -1,11 +1,13 @@
 {
-  rustPlatform,
-  pkg-config,
   alsa-lib,
+  lib,
+  pkg-config,
+  rustPlatform,
+  stdenv,
 }:
 let
   root = ../../../.;
-  cargo = builtins.fromTOML (builtins.readFile "${root}/Cargo.toml");
+  cargo = lib.importTOML "${root}/Cargo.toml";
 in
 rustPlatform.buildRustPackage {
   pname = cargo.package.name;
@@ -14,7 +16,7 @@ rustPlatform.buildRustPackage {
   cargoLock.lockFile = "${root}/Cargo.lock";
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ alsa-lib ];
+  buildInputs = if stdenv.hostPlatform.isLinux then [ alsa-lib ] else [ ];
 
   meta = {
     description = "A tui application for synchronising lyrics.";


### PR DESCRIPTION
When creating the Nix flake I only made a package for Linux but earlier today I realized that this should also support MacOS, so I added a package for that too (I also tested it and it does just work on Mac).

There were also some issues with the LSP in the Nix development shell that this PR also fixes.

Get Nixed once again.