### PR TITLE
feat: add home-manager module to nix flake

### DIFF
--- a/nix/modules/flake/default.nix
+++ b/nix/modules/flake/default.nix
@@ -3,6 +3,7 @@
   systems = import inputs.systems;
 
   imports = [
+    ./modules.nix
     ./overlays.nix
     ./packages.nix
     ./shells.nix

--- a/nix/modules/flake/modules.nix
+++ b/nix/modules/flake/modules.nix
@@ -1,0 +1,4 @@
+{ self, ... }:
+{
+  flake.homeModules.default = import "${self}/nix/modules/home" { inherit self; };
+}

--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -1,0 +1,45 @@
+{ self }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  inherit (pkgs.stdenv.hostPlatform) system isDarwin;
+
+  cfg = config.programs.lrxed;
+  package = if cfg.package != null then [ cfg.package ] else [ self.packages.${system}.default ];
+
+  settingsFormat = pkgs.formats.toml { };
+  settingsFile = settingsFormat.generate "lrxed-config.toml" cfg.settings;
+
+  settingsPath.xdg = "lrxed/config.toml";
+  settingsPath.darwin = "Library/Application Support/LunaPresent.lrxed/config.toml";
+in
+{
+  options.programs.lrxed = {
+    enable = lib.mkEnableOption "lrxed";
+
+    package = lib.mkPackageOption pkgs "lrxed" {
+      default = null;
+      nullable = true;
+    };
+
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = { };
+
+      description = ''
+        Configuration written to `$XDG_CONFIG_HOME/${settingsPath.xdg}` and `${settingsPath.darwin}`
+        on MacOS.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ package ];
+    xdg.configFile.${settingsPath.xdg}.source = settingsFile;
+    home.file.${settingsPath.darwin}.source = lib.mkIf isDarwin settingsFile;
+  };
+}


### PR DESCRIPTION
This PR adds a home-manager module to the Nix flake, which allows users to write something like this in their Nix configuration to install and configure lrxed:

```nix
{
  programs.lrxed = {
    enable = true;

    settings.keys.global.quit = [
      { key = "q"; }
      { key = "z"; }
    ];
  };
}
```

Tested on my MacBook where I'm currently using Nix.

Get nixed once more.