### PR TITLE
fix: fix the package variable in the nix home module

### DIFF
--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -9,7 +9,7 @@ let
   inherit (pkgs.stdenv.hostPlatform) system isDarwin;
 
   cfg = config.programs.lrxed;
-  package = if cfg.package != null then [ cfg.package ] else [ self.packages.${system}.default ];
+  package = if cfg.package != null then cfg.package else self.packages.${system}.default;
 
   settingsFormat = pkgs.formats.toml { };
   settingsFile = settingsFormat.generate "lrxed-config.toml" cfg.settings;


### PR DESCRIPTION
I makey mistaky and use the wrong value for the package variable in the Nix home module. This PR fixes it.