### PR TITLE
feat: add fallback to txt lyrics file if no matching lrc file is found

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,6 +1,5 @@
-use std::path::PathBuf;
-
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -8,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct Settings {
 	pub scrolloff: u16,
 	pub default_path: Option<PathBuf>,
+	pub replace_txt_file_on_save: bool,
 }
 
 impl Default for Settings {
@@ -15,6 +15,7 @@ impl Default for Settings {
 		Self {
 			scrolloff: 8,
 			default_path: None,
+			replace_txt_file_on_save: false,
 		}
 	}
 }

--- a/src/song.rs
+++ b/src/song.rs
@@ -1,3 +1,5 @@
+use thiserror::Error;
+
 use std::{
 	convert::identity,
 	path::{Path, PathBuf},
@@ -7,7 +9,6 @@ use lofty::{
 	file::TaggedFileExt,
 	tag::{ItemKey, Tag, TagType},
 };
-use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum LoadSongError {
@@ -62,7 +63,7 @@ impl Song {
 		}
 
 		if Self::is_valid_file_type(&path) {
-			Ok(Self::from_mp3(path.to_path_buf()))
+			Ok(Self::from_mp3(path))
 		} else {
 			Err(LoadSongError::InvalidFileType)
 		}
@@ -81,7 +82,15 @@ impl Song {
 		}
 	}
 
-	fn from_mp3(path: PathBuf) -> Song {
-		Self::new(path.clone(), path.with_extension("lrc"))
+	fn from_mp3(path: &Path) -> Song {
+		let lrc_path = if path.with_extension("lrc").exists() {
+			path.with_extension("lrc")
+		} else if path.with_extension("txt").exists() {
+			path.with_extension("txt")
+		} else {
+			path.with_extension("lrc")
+		};
+
+		Self::new(path.into(), lrc_path)
 	}
 }

--- a/src/state/lyrics_state.rs
+++ b/src/state/lyrics_state.rs
@@ -1,5 +1,5 @@
 use std::{
-	fs::{File, OpenOptions},
+	fs::{self, File, OpenOptions},
 	io::{BufReader, BufWriter},
 	path::PathBuf,
 	time::Duration,
@@ -39,13 +39,19 @@ impl LyricsState {
 		Ok(exists)
 	}
 
-	pub fn write_to_file(&mut self) -> eyre::Result<()> {
+	pub fn write_to_file(&mut self, replace_txt_file: bool) -> eyre::Result<()> {
 		if self
 			.lrc_file_path
 			.extension()
 			.is_some_and(|ext| ext == "txt")
 		{
-			self.lrc_file_path = self.lrc_file_path.with_extension("lrc");
+			let new_file_path = self.lrc_file_path.with_extension("lrc");
+
+			if replace_txt_file {
+				fs::rename(&self.lrc_file_path, &new_file_path)?;
+			}
+
+			self.lrc_file_path = new_file_path;
 		}
 
 		self.lyrics.write_to(&mut BufWriter::new(

--- a/src/state/lyrics_state.rs
+++ b/src/state/lyrics_state.rs
@@ -40,6 +40,14 @@ impl LyricsState {
 	}
 
 	pub fn write_to_file(&mut self) -> eyre::Result<()> {
+		if self
+			.lrc_file_path
+			.extension()
+			.is_some_and(|ext| ext == "txt")
+		{
+			self.lrc_file_path = self.lrc_file_path.with_extension("lrc");
+		}
+
 		self.lyrics.write_to(&mut BufWriter::new(
 			OpenOptions::new()
 				.read(false)
@@ -48,7 +56,9 @@ impl LyricsState {
 				.truncate(true)
 				.open(&self.lrc_file_path)?,
 		))?;
+
 		self.changed = false;
+
 		Ok(())
 	}
 

--- a/src/tui/views/confirm_back_modal.rs
+++ b/src/tui/views/confirm_back_modal.rs
@@ -10,7 +10,10 @@ impl ConfirmModal for ConfirmBackModal {
 	const PROMPT: &str = "Go back to file browser without saving changes?";
 
 	fn exec_yes(self, state: &mut AppState) -> eyre::Result<()> {
-		state.lyrics.write_to_file()?;
+		state
+			.lyrics
+			.write_to_file(state.config.settings.replace_txt_file_on_save)?;
+
 		state.should_go_back = true;
 
 		Ok(())

--- a/src/tui/views/confirm_quit_modal.rs
+++ b/src/tui/views/confirm_quit_modal.rs
@@ -10,8 +10,12 @@ impl ConfirmModal for ConfirmQuitModal {
 	const PROMPT: &str = "Save changes before quitting?";
 
 	fn exec_yes(self, state: &mut AppState) -> eyre::Result<()> {
-		state.lyrics.write_to_file()?;
+		state
+			.lyrics
+			.write_to_file(state.config.settings.replace_txt_file_on_save)?;
+
 		state.should_quit = true;
+
 		Ok(())
 	}
 

--- a/src/tui/views/editor_view.rs
+++ b/src/tui/views/editor_view.rs
@@ -46,7 +46,9 @@ impl InputHandler for EditorView {
 		{
 			match action {
 				Action::Save => {
-					state.lyrics.write_to_file()?;
+					state
+						.lyrics
+						.write_to_file(state.config.settings.replace_txt_file_on_save)?;
 				}
 				Action::MoveCursorY { amount } => {
 					state


### PR DESCRIPTION
This PR makes it so that if there's no lrc file for the current audio file, it will look for a txt file instead. When the file is saved, it will create an lrc file with the same name as the txt file and write to that file instead.

I've also added the `replace-txt-file-on-save` config option which will replace the txt file with the new lrc file on save.

Closes #16 