### PR TITLE
fix: fix error when replacing txt file with lrc file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ async fn main() -> Result<()> {
 
 		state.audio.audio_player = Some(state.audio.audio_device.try_play(song.mp3_file)?);
 
-		state.lyrics.load_file_if_exists(song.lrc_file)?;
+		state.song.load_file_if_exists(song.lrc_file)?;
 	} else {
 		state = AppState::new(View::FileTree);
 		state.file_browser.open_directory(&path)?;

--- a/src/song.rs
+++ b/src/song.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 
 use std::{
 	convert::identity,
+	fmt::Debug,
 	fs::File,
 	io::BufReader,
 	path::{Path, PathBuf},
@@ -43,12 +44,12 @@ impl From<Tag> for SongMeta {
 	}
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct Song {
 	pub mp3_file: PathBuf,
 	pub meta: Option<SongMeta>,
 	pub lrc_file: PathBuf,
-	pub lyrics: Option<Lyrics>,
+	pub lyrics: Lyrics,
 }
 
 impl Song {
@@ -88,10 +89,10 @@ impl Song {
 			if result.read_overwrite(reader).is_err() {
 				return Err(LoadSongError::FailedToReadLyrics);
 			} else {
-				Some(result)
+				result
 			}
 		} else {
-			None
+			Lyrics::default()
 		};
 
 		Ok(Self {

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -1,4 +1,4 @@
-use super::{AudioState, Config, FileBrowserState, LyricsState, ModalState, ToastState};
+use super::{AudioState, Config, FileBrowserState, ModalState, SongState, ToastState};
 use std::{ffi::OsString, io::stdout};
 
 use color_eyre::eyre;
@@ -16,7 +16,7 @@ use crate::{
 pub struct AppState {
 	pub audio: AudioState,
 	pub file_browser: FileBrowserState,
-	pub lyrics: LyricsState,
+	pub song: SongState,
 	pub modal: ModalState,
 	pub cursor: Cursor,
 	pub config: Config,
@@ -33,7 +33,7 @@ impl AppState {
 		Self {
 			audio: Default::default(),
 			file_browser: Default::default(),
-			lyrics: Default::default(),
+			song: Default::default(),
 			modal: Default::default(),
 			cursor: Default::default(),
 			config: Default::default(),
@@ -48,7 +48,7 @@ impl AppState {
 
 	pub fn open_in_editor(&mut self) -> eyre::Result<()> {
 		let mut buf = Vec::new();
-		self.lyrics.lyrics.write_to(&mut buf)?;
+		self.song.song.lyrics.write_to(&mut buf)?;
 		stdout().execute(LeaveAlternateScreen)?;
 
 		let bytes = edit::edit_bytes_with_builder(
@@ -56,8 +56,9 @@ impl AppState {
 			Builder::new()
 				.prefix(
 					&self
-						.lyrics
-						.lrc_file_path
+						.song
+						.song
+						.lrc_file
 						.file_stem()
 						.unwrap_or(Into::<OsString>::into("lyrics").as_os_str()),
 				)
@@ -76,10 +77,10 @@ impl AppState {
 			EditAction::RestoreState(buf),
 		);
 
-		let result = edit.execute_forwards(&mut self.lyrics.lyrics, &mut self.lyrics.time_index);
+		let result = edit.execute_forwards(&mut self.song.song.lyrics, &mut self.song.time_index);
 
-		self.lyrics.history.push(edit);
-		self.lyrics.changed = true;
+		self.song.history.push(edit);
+		self.song.changed = true;
 
 		result
 	}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -2,14 +2,14 @@ mod app_state;
 mod audio_state;
 mod config;
 mod file_browser_state;
-mod lyrics_state;
 mod modal_state;
+mod song_state;
 mod toast_state;
 
 pub use app_state::AppState;
 pub use audio_state::AudioState;
 pub use config::Config;
 pub use file_browser_state::{FileBrowserItem, FileBrowserState};
-pub use lyrics_state::LyricsState;
 pub use modal_state::{ConfirmBoxAction, ModalState};
+pub use song_state::SongState;
 pub use toast_state::ToastState;

--- a/src/state/song_state.rs
+++ b/src/state/song_state.rs
@@ -1,12 +1,12 @@
+use color_eyre::eyre;
+use ratatui::layout::Position;
+
 use std::{
 	fs::{self, File, OpenOptions},
 	io::{BufReader, BufWriter},
 	path::PathBuf,
 	time::Duration,
 };
-
-use color_eyre::eyre;
-use ratatui::layout::Position;
 
 use crate::{
 	lyrics::{
@@ -16,69 +16,64 @@ use crate::{
 	song::Song,
 };
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct LyricsState {
-	pub lyrics: Lyrics,
-	pub lrc_file_path: PathBuf,
+#[derive(Default, Clone, PartialEq, Eq)]
+pub struct SongState {
+	pub song: Song,
 	pub time_index: TimeIndex,
 	pub time_index_hint: TimeIndexHint,
 	pub history: History,
 	pub changed: bool,
 }
 
-impl LyricsState {
-	pub fn load_from_song(&mut self, song: &Song) -> eyre::Result<bool> {
-		if let Some(ref lyrics) = song.lyrics {
-			self.lyrics = lyrics.clone();
-		} else {
-			return self.load_file_if_exists(song.lrc_file.clone());
-		}
-
-		self.time_index = TimeIndex::new(self.lyrics.lines().iter());
+impl SongState {
+	pub fn load_from_song(&mut self, song: Song) -> eyre::Result<bool> {
+		self.song = song;
+		self.time_index = TimeIndex::new(self.song.lyrics.lines().iter());
 		self.time_index_hint = TimeIndexHint::default();
-		self.lrc_file_path = song.lrc_file.clone();
 
 		Ok(true)
 	}
 
 	pub fn load_file_if_exists(&mut self, lrc_path: PathBuf) -> eyre::Result<bool> {
 		let exists = if lrc_path.exists() {
-			self.lyrics
+			self.song
+				.lyrics
 				.read_overwrite(BufReader::new(File::open(&lrc_path)?))?;
 
 			true
 		} else {
-			self.lyrics = Lyrics::default();
+			self.song.lyrics = Lyrics::default();
 			false
 		};
-		self.time_index = TimeIndex::new(self.lyrics.lines().iter());
+		self.time_index = TimeIndex::new(self.song.lyrics.lines().iter());
 		self.time_index_hint = TimeIndexHint::default();
-		self.lrc_file_path = lrc_path;
+		self.song.lrc_file = lrc_path;
 		Ok(exists)
 	}
 
 	pub fn write_to_file(&mut self, replace_txt_file: bool) -> eyre::Result<()> {
 		if self
-			.lrc_file_path
+			.song
+			.lrc_file
 			.extension()
 			.is_some_and(|ext| ext == "txt")
 		{
-			let new_file_path = self.lrc_file_path.with_extension("lrc");
+			let new_file_path = self.song.lrc_file.with_extension("lrc");
 
 			if replace_txt_file {
-				fs::rename(&self.lrc_file_path, &new_file_path)?;
+				fs::rename(&self.song.lrc_file, &new_file_path)?;
 			}
 
-			self.lrc_file_path = new_file_path;
+			self.song.lrc_file = new_file_path;
 		}
 
-		self.lyrics.write_to(&mut BufWriter::new(
+		self.song.lyrics.write_to(&mut BufWriter::new(
 			OpenOptions::new()
 				.read(false)
 				.write(true)
 				.create(true)
 				.truncate(true)
-				.open(&self.lrc_file_path)?,
+				.open(&self.song.lrc_file)?,
 		))?;
 
 		self.changed = false;
@@ -89,13 +84,15 @@ impl LyricsState {
 	pub fn undo(&mut self) -> eyre::Result<()> {
 		self.changed = true;
 
-		self.history.undo(&mut self.lyrics, &mut self.time_index)
+		self.history
+			.undo(&mut self.song.lyrics, &mut self.time_index)
 	}
 
 	pub fn redo(&mut self) -> eyre::Result<()> {
 		self.changed = true;
 
-		self.history.redo(&mut self.lyrics, &mut self.time_index)
+		self.history
+			.redo(&mut self.song.lyrics, &mut self.time_index)
 	}
 
 	pub fn set_timestamp(
@@ -104,6 +101,7 @@ impl LyricsState {
 		timestamp: Option<Duration>,
 	) -> eyre::Result<()> {
 		let prev_val = self
+			.song
 			.lyrics
 			.time_at_cursor(cursor_pos.x, cursor_pos.y)
 			.map(|x| x.time());
@@ -117,7 +115,7 @@ impl LyricsState {
 				timestamp: prev_val,
 			},
 		);
-		edit.execute_forwards(&mut self.lyrics, &mut self.time_index)?;
+		edit.execute_forwards(&mut self.song.lyrics, &mut self.time_index)?;
 		self.history.push(edit);
 		self.changed = true;
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -88,7 +88,7 @@ impl InputHandler for App {
 			match state.config.keys.get_action(key_chord, Context::Global) {
 				// global keys here
 				Some(Action::Quit) => {
-					if state.lyrics.changed {
+					if state.song.changed {
 						state.active_modal = Some(Modal::ConfirmQuit);
 					} else {
 						state.should_quit = true;

--- a/src/tui/views/confirm_back_modal.rs
+++ b/src/tui/views/confirm_back_modal.rs
@@ -11,11 +11,12 @@ impl ConfirmModal for ConfirmBackModal {
 
 	fn exec_yes(self, state: &mut AppState) -> eyre::Result<()> {
 		state
-			.lyrics
+			.song
 			.write_to_file(state.config.settings.replace_txt_file_on_save)?;
+
 		state
 			.file_browser
-			.update_selected_lyrics(&state.lyrics.lyrics);
+			.update_selected_song(state.song.song.clone());
 
 		state.should_go_back = true;
 

--- a/src/tui/views/confirm_quit_modal.rs
+++ b/src/tui/views/confirm_quit_modal.rs
@@ -11,7 +11,7 @@ impl ConfirmModal for ConfirmQuitModal {
 
 	fn exec_yes(self, state: &mut AppState) -> eyre::Result<()> {
 		state
-			.lyrics
+			.song
 			.write_to_file(state.config.settings.replace_txt_file_on_save)?;
 
 		state.should_quit = true;

--- a/src/tui/widgets/lyrics.rs
+++ b/src/tui/widgets/lyrics.rs
@@ -21,7 +21,7 @@ impl StatefulWidget for LyricsWidget {
 	fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
 		let rows = cmp::min(
 			area.height,
-			state.lyrics.lyrics.line_count() - state.cursor.scroll().y,
+			state.song.song.lyrics.line_count() - state.cursor.scroll().y,
 		) as usize;
 
 		let layout = Layout::vertical(
@@ -32,7 +32,8 @@ impl StatefulWidget for LyricsWidget {
 		let (_fill, line_areas) = areas.split_last().unwrap();
 
 		let lyrics_lines = state
-			.lyrics
+			.song
+			.song
 			.lyrics
 			.lines()
 			.iter()
@@ -63,10 +64,10 @@ impl StatefulWidget for LyricsWidget {
 
 		let mut current_lyric_line = TimeIndexEntry::default();
 		if let Some(player) = &state.audio.audio_player {
-			(current_lyric_line, state.lyrics.time_index_hint) = state
-				.lyrics
+			(current_lyric_line, state.song.time_index_hint) = state
+				.song
 				.time_index
-				.find_seq(player.position(), state.lyrics.time_index_hint);
+				.find_seq(player.position(), state.song.time_index_hint);
 		}
 
 		for ((line_num, lyric_line), &line_area) in lyrics_lines.zip(line_areas) {


### PR DESCRIPTION
This PR does the following things:
- Replaces the `lyrics_state` with a `song_state` that stores the current song instead of just the lyrics.
- Get rid of the `RefCell` stuff in the `file_browser_state` and use a getter function instead.
- Fixes the issue that occurs when a txt file is replaced with an lrc file and then saved again from the editor.

Closes #25