### PR TITLE
perf: cache values used in file browser

### DIFF
--- a/src/lyrics/editing/edit_action.rs
+++ b/src/lyrics/editing/edit_action.rs
@@ -20,7 +20,8 @@ impl EditAction {
 				if lyrics.line_count() <= *idx {
 					return Err(eyre::eyre!("Line index out of range"));
 				}
-				lyrics.lines_mut()[*idx as usize].set_timestamp(*timestamp);
+
+				lyrics.set_timestamp_at_line(*idx as usize, *timestamp);
 				time_index.rebuild(lyrics.lines().iter());
 			}
 			EditAction::RestoreState(buffer) => {

--- a/src/lyrics/lyrics.rs
+++ b/src/lyrics/lyrics.rs
@@ -42,6 +42,7 @@ impl Lyrics {
 		if self.lines.is_empty() {
 			self.lines.push(Default::default());
 		}
+
 		Ok(())
 	}
 

--- a/src/song.rs
+++ b/src/song.rs
@@ -50,6 +50,7 @@ pub struct Song {
 	pub meta: Option<SongMeta>,
 	pub lrc_file: PathBuf,
 	pub lyrics: Lyrics,
+	pub has_file: bool,
 }
 
 impl Song {
@@ -82,17 +83,17 @@ impl Song {
 			.map_or(None, identity)
 			.map(SongMeta::from);
 
-		let lyrics = if let Ok(file) = File::open(&lrc_file) {
+		let (lyrics, has_file) = if let Ok(file) = File::open(&lrc_file) {
 			let reader = BufReader::new(file);
 			let mut result = Lyrics::default();
 
 			if result.read_overwrite(reader).is_err() {
 				return Err(LoadSongError::FailedToReadLyrics);
 			} else {
-				result
+				(result, true)
 			}
 		} else {
-			Lyrics::default()
+			(Lyrics::default(), false)
 		};
 
 		Ok(Self {
@@ -100,6 +101,7 @@ impl Song {
 			mp3_file,
 			lrc_file,
 			lyrics,
+			has_file,
 		})
 	}
 

--- a/src/state/song_state.rs
+++ b/src/state/song_state.rs
@@ -76,6 +76,7 @@ impl SongState {
 				.open(&self.song.lrc_file)?,
 		))?;
 
+		self.song.has_file = true;
 		self.changed = false;
 
 		Ok(())

--- a/src/tui/views/file_tree_view.rs
+++ b/src/tui/views/file_tree_view.rs
@@ -199,7 +199,7 @@ impl StatefulWidget for FileTreeView {
 				Span::styled(format!("{} {}", icon, item.name()), style).render(left, buf);
 
 				if let FileBrowserItem::Song(song) = item {
-					if song.lrc_file.exists() {
+					if song.has_file {
 						let sync_percentage = song.lyrics.sync_percentage();
 
 						let color = match sync_percentage {


### PR DESCRIPTION
The PR adds caching for certain values used in the file browser so that these don't have to be recalculated every frame. These values are:
- Wether a song has a certain file associated with it.
- The sync percentage of the lyrics.

A code change that should be kept in mind is that I removed the `lines_mut` function from the `Lyrics` struct. This is because the sync percentage is now a value in the struct that needs to be recalculated whenever the lyrics change. Allowing editing of the lyrics using the `lines_mut` function means that whenever it's used to modify the lyrics, you'd have to remember to update the sync percentage as well. This creates a lot of room for bugs, so I think it's better to only allow modifying the lyrics with specialized functions on the `Lyrics` struct.

Closes #29