### PR TITLE
feat(config): add settings.sync-offset option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ratatui = "0.29.0"
 rodio = { version = "0.20.1", default-features = false, features = ["symphonia-all"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-serde_with = "3.12.0"
+serde_with = { version = "3.12.0", features = ["chrono"] }
 serde_yml = "0.0.12"
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.12"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use serde_with::{DurationSecondsWithFrac, serde_as};
+use serde_with::{DurationSecondsWithFrac, chrono::TimeDelta, serde_as};
 use std::{path::PathBuf, time::Duration};
 
 #[serde_as]
@@ -12,6 +12,8 @@ pub struct Settings {
 	pub replace_txt_file_on_save: bool,
 	#[serde_as(as = "DurationSecondsWithFrac<f64>")]
 	pub notification_timeout: Duration,
+	#[serde_as(as = "DurationSecondsWithFrac<f64>")]
+	pub sync_offset: TimeDelta,
 }
 
 impl Default for Settings {
@@ -21,6 +23,7 @@ impl Default for Settings {
 			default_path: None,
 			replace_txt_file_on_save: false,
 			notification_timeout: Duration::from_secs(5),
+			sync_offset: TimeDelta::zero(),
 		}
 	}
 }

--- a/src/tui/views/editor_view.rs
+++ b/src/tui/views/editor_view.rs
@@ -9,6 +9,7 @@ use ratatui::{
 	layout::{Constraint, Layout, Position},
 	widgets::StatefulWidget,
 };
+use serde_with::chrono::TimeDelta;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{
@@ -286,9 +287,15 @@ impl InputHandler for EditorView {
 				}
 				Action::SyncTimestamp => {
 					let player = get_player(state)?;
-					state
-						.song
-						.set_timestamp(state.cursor.pos(), Some(player.position()))?;
+					state.song.set_timestamp(
+						state.cursor.pos(),
+						Some(
+							(TimeDelta::from_std(player.position()).unwrap_or_default()
+								+ state.config.settings.sync_offset)
+								.to_std()
+								.unwrap_or_default(),
+						),
+					)?;
 					state
 						.cursor
 						.set_y(state.cursor.pos().y + 1)

--- a/src/tui/views/editor_view.rs
+++ b/src/tui/views/editor_view.rs
@@ -293,7 +293,8 @@ impl InputHandler for EditorView {
 							(TimeDelta::from_std(player.position()).unwrap_or_default()
 								+ state.config.settings.sync_offset)
 								.to_std()
-								.unwrap_or_default(),
+								.unwrap_or_default()
+								.min(player.duration()),
 						),
 					)?;
 					state


### PR DESCRIPTION
This value, in seconds, will be added to the current progress when pressing the sync (space) key. If you wish to use this, you will likely want to set it to a small negative value, like -0.1. Defaults to 0.

Closes #27 